### PR TITLE
feat: Add layout for customer registration and order view with client information and purchase details

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,6 +12,32 @@ export interface CancelledReason {
 	cancel_reason: string;
 }
 
+export interface Address {
+	user_id: number;
+	street: string;
+	street_number: string;
+	address_complement: string;
+	neighborhood: string;
+	city: string;
+	state: string;
+	country: string;
+	zipcode: string;
+}
+
+export interface Payment {
+	payment_id: number;
+	order_id: number;
+	amount: string;
+	token: string;
+	gateway_payment_id: number;
+	status: string;
+	authorization: string;
+	payment_method: string;
+	payment_gateway: string;
+	amount_with_fee: string;
+	freight_amount: string;
+}
+
 export interface DataProducts {
 	products: Product[];
 	page: number;
@@ -51,6 +77,7 @@ export interface DataSalesOrders {
 	freight: any;
 	coupon_id: any;
 	items: DataProductItems[];
+	payment: Payment;
 }
 
 export interface DataInventory {
@@ -79,6 +106,7 @@ export type User = {
 	email: string;
 	document: string;
 	phone: string;
+	addresses: Address[];
 };
 
 export interface OrderItem {

--- a/src/routes/admin/sales/new/+page.svelte
+++ b/src/routes/admin/sales/new/+page.svelte
@@ -113,17 +113,33 @@
 						{/each}
 					</div>
 				</div>
+
 				<div>
-					<label for="IdOrder" class="block text-sm font-medium text-gray-700">ID do Pedido</label>
-					<Input id="IdOrder" value={order.order_id} readonly />
+					<label for="username" class="block text-sm font-medium text-gray-700"
+						>Usuário
+					</label><Input id="username" value={order.user.name} readonly />
+				</div>
+
+				<!-- ajustar -->
+				<div>
+					<label for="address" class="block text-sm font-medium text-gray-700"
+						>Endereço
+					</label><Input id="address" value={'Avenida das torres, 1600'} readonly />
+				</div>
+				<!-- ajustar -->
+
+				<div>
+					<label for="document" class="block text-sm font-medium text-gray-700"
+						>Documento
+					</label><Input id="document" value={order.user.document} readonly />
 				</div>
 
 				<div>
-					<label for="IdAffiliate" class="block text-sm font-medium text-gray-700"
-						>ID da Afiliação
-					</label>
-
-					<Input id="IdAffiliate" bind:value={order.affiliate_id} />
+					<label for="phone" class="block text-sm font-medium text-gray-700">Telefone </label><Input
+						id="phone"
+						value={order.user.phone}
+						readonly
+					/>
 				</div>
 
 				<div>
@@ -136,10 +152,6 @@
 						readonly
 					/>
 				</div>
-				<div>
-					<label for="ID do Pedido" class="block text-sm font-medium text-gray-700">Desconto</label>
-					<Input id="Desconto" bind:value={order.discount} />
-				</div>
 
 				<div>
 					<label for="ID do Pedido" class="block text-sm font-medium text-gray-700"
@@ -151,16 +163,6 @@
 					/>
 				</div>
 				<div>
-					<label for="IdUser" class="block text-sm font-medium text-gray-700"
-						>ID do Usuário
-					</label><Input id="IdUser" value={order.user.user_id} readonly />
-				</div>
-				<div>
-					<label for="username" class="block text-sm font-medium text-gray-700"
-						>Usuário
-					</label><Input id="username" value={order.user.name} readonly />
-				</div>
-				<div>
 					<label for="email" class="block text-sm font-medium text-gray-700">E-mail </label><Input
 						id="email"
 						value={order.user.email}
@@ -170,13 +172,16 @@
 				<div>
 					<label for="frete" class="block text-sm font-medium text-gray-700"
 						>Tipo do Frete
-					</label><Input id="frete" bind:value={order.freight} />
+					</label><Input id="frete" bind:value={order.freight} readonly />
 				</div>
+
+				<!-- ajustar -->
 				<div>
-					<label for="IdCoupon" class="block text-sm font-medium text-gray-700"
-						>ID do Cupom
-					</label><Input id="IdCoupon" value={order.coupon_id ?? 'sem cupom'} />
+					<label for="total" class="block text-sm font-medium text-gray-700"
+						>Valor Total
+					</label><Input id="total" value={currencyFormat(Number(order.items[0].price))} readonly />
 				</div>
+				<!-- ajustar -->
 			</form>
 		{/if}
 		<div class="my-8 space-y-4" role="group">

--- a/src/routes/admin/sales/new/+page.svelte
+++ b/src/routes/admin/sales/new/+page.svelte
@@ -23,12 +23,26 @@
 			name: '',
 			email: '',
 			document: '',
-			phone: ''
+			phone: '',
+			addresses: []
 		},
 		freight: '',
 		coupon_id: '',
 		customer_id: '',
-		items: []
+		items: [],
+		payment: {
+			payment_id: 0,
+			order_id: 0,
+			amount: '',
+			token: ',',
+			gateway_payment_id: 0,
+			status: '',
+			authorization: '',
+			payment_method: '',
+			payment_gateway: '',
+			amount_with_fee: '',
+			freight_amount: ''
+		}
 	};
 
 	let showCancelReason = false;
@@ -63,6 +77,25 @@
 		showCancelReason = false;
 		console.log(showTrackingCode);
 		console.log(showCancelReason);
+	}
+
+	function getAdress(orderUser: any) {
+		return `${orderUser.addresses[0].street} , ${orderUser.addresses[0].neighborhood}, ${orderUser.addresses[0].street_number}`;
+	}
+
+	function getState(orderUser: any) {
+		return `${orderUser.addresses[0].city} , ${orderUser.addresses[0].state}, ${orderUser.addresses[0].country} `;
+	}
+
+	function currencyFormatFreight(value: number, locale = 'pt-BR', type?: string): string {
+		if (value === 0.01 && type === 'freight') {
+			return 'Grátis';
+		}
+
+		return new Intl.NumberFormat(locale, {
+			style: 'currency',
+			currency: 'BRL'
+		}).format(value);
 	}
 
 	async function submitTrackingCode() {
@@ -124,7 +157,13 @@
 				<div>
 					<label for="address" class="block text-sm font-medium text-gray-700"
 						>Endereço
-					</label><Input id="address" value={'Avenida das torres, 1600'} readonly />
+					</label><Input id="address" value={getAdress(order.user)} readonly />
+				</div>
+
+				<div>
+					<label for="state" class="block text-sm font-medium text-gray-700"
+						>Residencia
+					</label><Input id="state" value={getState(order.user)} readonly />
 				</div>
 				<!-- ajustar -->
 
@@ -175,11 +214,25 @@
 					</label><Input id="frete" bind:value={order.freight} readonly />
 				</div>
 
+				<div>
+					<label for="freight_amount" class="block text-sm font-medium text-gray-700"
+						>Valor do Frete
+					</label><Input
+						id="freight_amount"
+						value={currencyFormatFreight(
+							Number(order.payment.freight_amount),
+							undefined,
+							'freight'
+						)}
+						readonly
+					/>
+				</div>
+
 				<!-- ajustar -->
 				<div>
 					<label for="total" class="block text-sm font-medium text-gray-700"
 						>Valor Total
-					</label><Input id="total" value={currencyFormat(Number(order.items[0].price))} readonly />
+					</label><Input id="total" value={currencyFormat(Number(order.payment.amount))} readonly />
 				</div>
 				<!-- ajustar -->
 			</form>


### PR DESCRIPTION
Este pull request implementa o layout de cadastro e visualização de pedidos, incluindo as seguintes informações:

- Nome do cliente: Campo exibido e/ou editável no formulário.
- Endereço de entrega: Inclui rua, número, bairro, cidade, estado e CEP.
- CPF: Máscara aplicada no campo de CPF para facilitar a visualização.
- Telefone para contato: Campo para inserir o telefone de cadastro do cliente.
- Produtos comprados: Exibição dos produtos adicionados ao pedido.
- Quantidade: Quantidade de cada produto no pedido.
- Valor unitário: Preço de cada produto adicionado.
- Valor total: Cálculo do valor total do pedido, considerando todos os produtos.
- Tipo de frete: Seletor para o tipo de frete escolhido pelo cliente.