### PR TITLE
fix: fix bug in the createCouponsModal

### DIFF
--- a/src/lib/components/coupon/modal/CreateCoupon.svelte
+++ b/src/lib/components/coupon/modal/CreateCoupon.svelte
@@ -44,11 +44,15 @@
 	}
 
 	async function createCoupon() {
-		coupon.affiliate_id = coupon.affiliate_id.value;
-		coupon.product_id = coupon.product_id.value;
-		coupon.commission_percentage = coupon.commission_percentage.value;
+		const payload = {
+			...coupon,
+			product_id: coupon.product_id.value === 0 ? null : coupon.product_id.value,
+			affiliate_id: coupon.affiliate_id.value === 0 ? null : coupon.affiliate_id.value,
+			commission_percentage:
+				coupon.commission_percentage.value === 0 ? null : coupon.commission_percentage.value
+		};
 
-		const res = coupons.post(`${details.base_url}/coupon/`, coupon, details.token);
+		const res = coupons.post(`${details.base_url}/coupon/`, payload, details.token);
 
 		if (res) {
 			closeModal();
@@ -64,10 +68,7 @@
 	}
 
 	function handlePercentChange(event: any) {
-		console.log(coupon.commission_percentage);
 		coupon.commission_percentage.value = Number(event.target.value);
-
-		console.log(coupon.commission_percentage);
 	}
 </script>
 


### PR DESCRIPTION
- Adicionado objeto payload para formatar os dados antes do envio à API.
- product_id, affiliate_id e commission_percentage são transformados de { value, name } para number ou null no payload.
- Mantida a estrutura original de coupon para exibição correta no modal, enquanto o payload atende ao formato esperado pela API.