### PR TITLE
Feat: adicionar payment_method à tabela e aos detalhes de vendas

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -113,6 +113,14 @@ export const statusMap: Record<string, string> = {
 	CANCELLED: 'Cancelado'
 };
 
+export const paymentMethodMap: Record<string, string> = {
+	credit_card: 'Cartão de Crédito',
+	boleto: 'Boleto',
+	pix: 'Pix',
+	debit_card: 'Cartão de Débito',
+	cash: 'Dinheiro'
+};
+
 export function formatPercentage(value: number): string {
 	return `${(value * 100).toFixed(2)}%`;
 }

--- a/src/routes/admin/sales/+page.svelte
+++ b/src/routes/admin/sales/+page.svelte
@@ -18,7 +18,8 @@
 		Dropdown,
 		DropdownItem,
 		DropdownDivider,
-		Toast
+		Toast,
+		Spinner
 	} from 'flowbite-svelte';
 	import {
 		AngleLeftOutline,
@@ -27,11 +28,13 @@
 		ChevronDoubleLeftOutline,
 		ChevronDoubleRightOutline
 	} from 'flowbite-svelte-icons';
-	import { getStatusTranslation } from '$lib/utils';
+	import { getStatusTranslation, paymentMethodMap } from '$lib/utils';
 	import CancelOrder from '$lib/components/sales/SalesModal.svelte';
 
 	export let data: any;
+
 	let isModalOpen = false;
+	let isLoading = false;
 	let order_id: number = 0;
 	let notification = false;
 	let counter = 6;
@@ -71,14 +74,20 @@
 	}
 
 	async function refreshOrders() {
+		isLoading = true;
 		if (data?.orders) {
 			await ordersStore.get(
 				`${data.base_url}/order/orders?page=${currentPage}&offset=${rowsPerPage}`,
 				data.orders.access_token
 			);
+
+			isLoading = false;
 		} else {
 			console.error('Missing data or access token');
+			isLoading = false;
 		}
+
+		isLoading = false;
 	}
 
 	async function handleRowsPerPageChange(event: any) {
@@ -159,136 +168,145 @@
 	</div>
 
 	<div class="w-full mx-auto mt-12">
-		<Table hoverable={true}>
-			<TableHead>
-				<TableHeadCell class="pl-0 cursor-pointer">Id</TableHeadCell>
-				<TableHeadCell class=" cursor-pointer">Data</TableHeadCell>
-				<TableHeadCell class="cursor-pointer">Rastreio</TableHeadCell>
-				<TableHeadCell class="pl-0 cursor-pointer">Status do pedido</TableHeadCell>
-				<TableHeadCell class="pl-0 cursor-pointer">Nome do comprador</TableHeadCell>
-				<TableHeadCell class="pl-0 cursor-pointer">Tipo de frete</TableHeadCell>
-				<TableHeadCell class="pl-0 cursor-pointer">ID do Cupom</TableHeadCell>
-				<TableHeadCell class="pl-0 cursor-pointer">Motivo do cancelamento</TableHeadCell>
-				<TableHeadCell class="pl-0 cursor-pointer">Data do cancelamento</TableHeadCell>
-				<TableHeadCell class="pl-0 cursor-pointer">Editar</TableHeadCell>
-			</TableHead>
-			<TableBody tableBodyClass="divide-y">
-				{#each items as order}
-					<TableBodyRow>
-						<TableBodyCell tdClass="py-2">{order.order_id}</TableBodyCell>
-						<TableBodyCell tdClass="p-2"
-							>{new Date(order.order_date).toLocaleDateString()}</TableBodyCell
-						>
-						<TableBodyCell tdClass="py-2">
-							<Badge
-								class="w-32 text-center px-2 py-1 rounded-full border"
-								border
-								color={order.tracking_number && order.order_status === 'PAYMENT_PENDING'
-									? 'yellow'
-									: order.tracking_number
-										? 'green'
-										: 'red'}
+		{#if isLoading}
+			<div class="flex justify-center items-center">
+				<Spinner size="10" />
+			</div>
+		{:else}
+			<Table hoverable={true}>
+				<TableHead>
+					<TableHeadCell class="pl-0 cursor-pointer">Id</TableHeadCell>
+					<TableHeadCell class=" cursor-pointer">Data</TableHeadCell>
+					<TableHeadCell class="cursor-pointer">Rastreio</TableHeadCell>
+					<TableHeadCell class="pl-0 cursor-pointer">Status do pedido</TableHeadCell>
+					<TableHeadCell class="pl-0 cursor-pointer">Nome do comprador</TableHeadCell>
+					<TableHeadCell class="pl-0 cursor-pointer">Tipo de frete</TableHeadCell>
+					<TableHeadCell class="pl-0 cursor-pointer">ID do Cupom</TableHeadCell>
+					<TableHeadCell class="pl-0 cursor-pointer">Motivo do cancelamento</TableHeadCell>
+					<TableHeadCell class="pl-0 cursor-pointer">Método de pagamento</TableHeadCell>
+					<TableHeadCell class="pl-0 cursor-pointer">Editar</TableHeadCell>
+				</TableHead>
+				<TableBody tableBodyClass="divide-y">
+					{#each items as order}
+						<TableBodyRow>
+							<TableBodyCell tdClass="py-2">{order.order_id}</TableBodyCell>
+							<TableBodyCell tdClass="p-2"
+								>{new Date(order.order_date).toLocaleDateString()}</TableBodyCell
 							>
-								{order.tracking_number ? 'Enviado' : 'não enviado'}
-							</Badge>
-						</TableBodyCell>
-
-						<TableBodyCell tdClass="py-2">
-							<Badge
-								class="w-32 text-center px-2 py-1 rounded-full border"
-								border
-								color={order.order_status === 'PAYMENT_PENDING'
-									? 'yellow'
-									: order.order_status === 'SHIPPING_COMPLETE'
-										? 'green'
-										: order.order_status === 'PAYMENT_PAID'
+							<TableBodyCell tdClass="py-2">
+								<Badge
+									class="w-32 text-center px-2 py-1 rounded-full border"
+									border
+									color={order.tracking_number && order.order_status === 'PAYMENT_PENDING'
+										? 'yellow'
+										: order.tracking_number
 											? 'green'
 											: 'red'}
-							>
-								{getStatusTranslation(order.order_status)}
-							</Badge>
-						</TableBodyCell>
-						<TableBodyCell tdClass="py-2">{order.user.name}</TableBodyCell>
-						<TableBodyCell tdClass="py-2">{order.freight}</TableBodyCell>
-						<TableBodyCell tdClass="py-2">{order.coupon_id ?? 'sem cupom'}</TableBodyCell>
-						<TableBodyCell tdClass="py-2">{order.cancelled_reason ?? ''}</TableBodyCell>
-						<TableBodyCell tdClass="py-2">{order.cancelled_at ?? ''}</TableBodyCell>
-						<TableBodyCell tdClass="py-2">
-							<Button
-								variant="primary"
-								additionalClass="w-full sm:w-auto sm:text-base text-sm py-1 px-2 sm:py-2 sm:px-4"
-								>Gerenciar</Button
-							>
-							<Dropdown class="w-48 p-3 space-y-1">
-								<DropdownItem
-									on:click={() => {
-										goto(`/admin/sales/new?order_id=${order.order_id}`);
-									}}>Detalhes</DropdownItem
 								>
-								{#if order.order_status !== 'CANCELLED'}
-									<DropdownDivider />
+									{order.tracking_number ? 'Enviado' : 'não enviado'}
+								</Badge>
+							</TableBodyCell>
+
+							<TableBodyCell tdClass="py-2">
+								<Badge
+									class="w-32 text-center px-2 py-1 rounded-full border"
+									border
+									color={order.order_status === 'PAYMENT_PENDING'
+										? 'yellow'
+										: order.order_status === 'SHIPPING_COMPLETE'
+											? 'green'
+											: order.order_status === 'PAYMENT_PAID'
+												? 'green'
+												: 'red'}
+								>
+									{getStatusTranslation(order.order_status)}
+								</Badge>
+							</TableBodyCell>
+							<TableBodyCell tdClass="py-2">{order.user.name}</TableBodyCell>
+							<TableBodyCell tdClass="py-2">{order.freight}</TableBodyCell>
+							<TableBodyCell tdClass="py-2">{order.coupon_id ?? 'sem cupom'}</TableBodyCell>
+							<TableBodyCell tdClass="py-2">{order.cancelled_reason ?? ''}</TableBodyCell>
+							<TableBodyCell tdClass="py-2"
+								>{paymentMethodMap[order.payment.payment_method]}</TableBodyCell
+							>
+							<TableBodyCell tdClass="py-2">
+								<Button
+									variant="primary"
+									additionalClass="w-full sm:w-auto sm:text-base text-sm py-1 px-2 sm:py-2 sm:px-4"
+									>Gerenciar</Button
+								>
+								<Dropdown class="w-48 p-3 space-y-1">
 									<DropdownItem
 										on:click={() => {
-											handleCancelOrder(order.order_id);
-										}}>Cancelar pedido</DropdownItem
+											goto(`/admin/sales/new?order_id=${order.order_id}`);
+										}}>Detalhes</DropdownItem
 									>
-								{/if}
-							</Dropdown>
-						</TableBodyCell>
-					</TableBodyRow>
-				{/each}
-			</TableBody>
-		</Table>
+									{#if order.order_status !== 'CANCELLED'}
+										<DropdownDivider />
+										<DropdownItem
+											on:click={() => {
+												handleCancelOrder(order.order_id);
+											}}>Cancelar pedido</DropdownItem
+										>
+									{/if}
+								</Dropdown>
+							</TableBodyCell>
+						</TableBodyRow>
+					{/each}
+				</TableBody>
+			</Table>
 
-		<div class="w-full flex justify-end items-center gap-2 my-3">
-			<Label>Quantidade por página</Label>
-			<Select
-				variant="outlined"
-				bind:value={rowsPerPage}
-				noLabel
-				class="w-24"
-				placeholder="Escolha uma opção"
-				items={[
-					{ value: 10, name: '10' },
-					{ value: 20, name: '20' },
-					{ value: 50, name: '50' },
-					{ value: 100, name: '100' }
-				]}
-				on:change={handleRowsPerPageChange}
-			/>
+			<div class="w-full flex justify-end items-center gap-2 my-3">
+				<Label>Quantidade por página</Label>
+				<Select
+					variant="outlined"
+					bind:value={rowsPerPage}
+					noLabel
+					class="w-24"
+					placeholder="Escolha uma opção"
+					items={[
+						{ value: 10, name: '10' },
+						{ value: 20, name: '20' },
+						{ value: 50, name: '50' },
+						{ value: 100, name: '100' }
+					]}
+					on:change={handleRowsPerPageChange}
+				/>
 
-			{start + 1}-{end} de {data.orders.totalRecords}
+				{start + 1}-{end} de {data.orders.totalRecords}
 
-			<button
-				on:click={firstPage}
-				class="cursor-pointer disabled:pointer-events-none disabled:text-gray-400"
-				disabled={currentPage === 1}
-			>
-				<ChevronDoubleLeftOutline class="w-7 h-7 outline-none" />
-			</button>
-			<button
-				on:click={prevPage}
-				class="cursor-pointer disabled:pointer-events-none disabled:text-gray-400"
-				disabled={currentPage === 1}
-			>
-				<AngleLeftOutline class="w-5 h-5 outline-none" />
-			</button>
-			<button
-				on:click={async () => await nextPage()}
-				class="cursor-pointer disabled:pointer-events-none disabled:text-gray-400"
-				disabled={currentPage === endPage}
-			>
-				<AngleRightOutline class="w-5 h-5 outline-none" />
-			</button>
-			<button
-				on:click={lastPage}
-				class="cursor-pointer disabled:pointer-events-none disabled:text-gray-400"
-				disabled={currentPage === endPage}
-			>
-				<ChevronDoubleRightOutline class="w-7 h-7 outline-none" />
-			</button>
-		</div>
+				<button
+					on:click={firstPage}
+					class="cursor-pointer disabled:pointer-events-none disabled:text-gray-400"
+					disabled={currentPage === 1}
+				>
+					<ChevronDoubleLeftOutline class="w-7 h-7 outline-none" />
+				</button>
+				<button
+					on:click={prevPage}
+					class="cursor-pointer disabled:pointer-events-none disabled:text-gray-400"
+					disabled={currentPage === 1}
+				>
+					<AngleLeftOutline class="w-5 h-5 outline-none" />
+				</button>
+				<button
+					on:click={async () => await nextPage()}
+					class="cursor-pointer disabled:pointer-events-none disabled:text-gray-400"
+					disabled={currentPage === endPage}
+				>
+					<AngleRightOutline class="w-5 h-5 outline-none" />
+				</button>
+				<button
+					on:click={lastPage}
+					class="cursor-pointer disabled:pointer-events-none disabled:text-gray-400"
+					disabled={currentPage === endPage}
+				>
+					<ChevronDoubleRightOutline class="w-7 h-7 outline-none" />
+				</button>
+			</div>
+		{/if}
 	</div>
+
 	<CancelOrder
 		isOpen={isModalOpen}
 		selectedOrder={order_id}

--- a/src/routes/admin/sales/new/+page.svelte
+++ b/src/routes/admin/sales/new/+page.svelte
@@ -4,7 +4,7 @@
 	import { goto } from '$app/navigation';
 	import { Button, Input, Spinner, Card } from 'flowbite-svelte';
 	import { getOrderById } from '$lib/stores/sales';
-	import { getStatusTranslation } from '$lib/utils.js';
+	import { getStatusTranslation, paymentMethodMap } from '$lib/utils';
 	import type { DataSalesOrders } from '$lib/types';
 	import { currencyFormat } from '$lib/utils';
 
@@ -168,6 +168,16 @@
 					<label for="state" class="block text-sm font-medium text-gray-700"
 						>Residencia
 					</label><Input id="state" value={getState(order.user)} readonly />
+				</div>
+
+				<div>
+					<label for="payment_type" class="block text-sm font-medium text-gray-700"
+						>Método de pagamento
+					</label><Input
+						id="payment_type"
+						value={paymentMethodMap[order.payment.payment_method]}
+						readonly
+					/>
 				</div>
 
 				<div>


### PR DESCRIPTION
# Descrição

- Adiciona o método de pagamento à exibição na tabela de vendas e nos detalhes de vendas.
- Implementa o mapeamento de métodos de pagamento (paymentMethodMap) para mostrar nomes amigáveis em vez dos valores brutos.
- Ajusta o layout para acomodar o novo campo nas interfaces de tabela e detalhes.

### Impacto:

- Melhora a usabilidade ao exibir informações claras sobre o método de pagamento.
- Facilita a identificação e compreensão dos métodos utilizados em cada venda.

