### PR TITLE
Fix: Atualiza o Editor para Renderizar Conteúdo HTML com innerHTML e Corrige o Fluxo de Dados

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@felte/reporter-svelte": "^1.1.11",
 		"@felte/validator-zod": "^1.0.17",
 		"@imask/svelte": "^7.6.0",
-		"quill": "^2.0.2",
+		"quill": "2.0.3",
 		"tailwind-variants": "0.2.1",
 		"zod": "^3.22.4"
 	},

--- a/src/lib/components/Editor.svelte
+++ b/src/lib/components/Editor.svelte
@@ -2,7 +2,7 @@
 	import { createEventDispatcher, onMount } from 'svelte';
 
 	interface Quill {
-		getSemanticHTML(): string;
+		root: HTMLElement;
 		on(event: string, callback: () => void): void;
 	}
 
@@ -32,16 +32,20 @@
 			theme: 'snow',
 			placeholder: placeholder
 		});
+
 		if (value) {
-			quill.setText(value);
+			quill.root.innerHTML = value;
 		}
 	});
 
-	$: quill &&
-		quill.on('text-change', () => {
-			value = quill.getSemanticHTML();
-			dispatch('change', { value: quill.getSemanticHTML() });
-		});
+	$: {
+		if (quill) {
+			quill.on('text-change', () => {
+				const content = quill.root.innerHTML;
+				dispatch('change', { value: content });
+			});
+		}
+	}
 </script>
 
 <div>

--- a/src/routes/admin/products/new/+page.svelte
+++ b/src/routes/admin/products/new/+page.svelte
@@ -129,6 +129,10 @@
 		<h2 class="text-xl font-bold mt-4">Descrição do produto:</h2>
 		<div class="my-10">
 			<Editor label="Conteúdo" placeholder="Descrição..." on:change={handleChangeContent} />
+
+			<div class="mt-5">
+				{@html content}
+			</div>
 		</div>
 		<div class="my-10">
 			<Editor label="Modo de uso" placeholder="Modo de uso..." on:change={handleChangeHowToUse} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,10 +2529,10 @@ quill-delta@^5.1.0:
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
 
-quill@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/quill/-/quill-2.0.2.tgz#5b26bc10a74e9f7fdcfdb5156b3133a3ebf0a814"
-  integrity sha512-QfazNrhMakEdRG57IoYFwffUIr04LWJxbS/ZkidRFXYCQt63c1gK6Z7IHUXMx/Vh25WgPBU42oBaNzQ0K1R/xw==
+quill@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-2.0.3.tgz#752765a31d5a535cdc5717dc49d4e50099365eb1"
+  integrity sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==
   dependencies:
     eventemitter3 "^5.0.1"
     lodash-es "^4.17.21"


### PR DESCRIPTION
# Descrição

Este PR resolve o problema de renderização de conteúdo no editor Quill. A principal mudança foi a substituição do método getSemanticHTML() por quill.root.innerHTML para capturar e definir o conteúdo em formato HTML. Além disso, foi corrigido o fluxo de dados entre o componente Editor e o componente pai, permitindo que o conteúdo HTML seja transmitido corretamente para o componente pai através do evento change. Isso garante que o conteúdo editado seja renderizado como HTML no componente que recebe a atualização.

## Alterações realizadas:

- Substituição do uso de getSemanticHTML() para quill.root.innerHTML.
- Atualização do evento text-change para capturar conteúdo HTML ao invés de Delta.
- Correção na forma como o valor inicial do editor é configurado a partir da prop value.